### PR TITLE
feat: disable winbar when there are no tasks

### DIFF
--- a/.do_tasks
+++ b/.do_tasks
@@ -1,4 +1,3 @@
-Filter by file type instead of win type. Filtering by win type can cause side effects
 reload tasks when task file has been changed outside of :DoEdit
 Make :cd and :tcd check fo task file again
 Add demo video

--- a/.do_tasks
+++ b/.do_tasks
@@ -1,4 +1,4 @@
-disable winbar when there are no tasks
+Filter by file type instead of win type. Filtering by win type can cause side effects
 reload tasks when task file has been changed outside of :DoEdit
 Make :cd and :tcd check fo task file again
 Add demo video

--- a/.do_tasks
+++ b/.do_tasks
@@ -1,3 +1,4 @@
+disable winbar when there are no tasks
 reload tasks when task file has been changed outside of :DoEdit
 Make :cd and :tcd check fo task file again
 Add demo video

--- a/.do_tasks
+++ b/.do_tasks
@@ -1,3 +1,4 @@
+write unit tests
 reload tasks when task file has been changed outside of :DoEdit
 Make :cd and :tcd check fo task file again
 Add demo video

--- a/lua/do.lua
+++ b/lua/do.lua
@@ -27,6 +27,7 @@ end, { nargs = 1, bang = true })
 
 create("Done", function(args)
   -- not sure if I like this. 
+   print("function#if args.bang:", vim.inspect(args.bang)) -- __AUTO_GENERATED_PRINT_VAR__
   if not args.bang then
     core.show_message(kaomoji.doubt() .. " Really? If so, use Done!", "ErrorMsg")
     return

--- a/lua/do.lua
+++ b/lua/do.lua
@@ -27,9 +27,8 @@ end, { nargs = 1, bang = true })
 
 create("Done", function(args)
   -- not sure if I like this. 
-   print("function#if args.bang:", vim.inspect(args.bang)) -- __AUTO_GENERATED_PRINT_VAR__
   if not args.bang then
-    core.show_message(kaomoji.doubt() .. " Really? If so, use Done!", "ErrorMsg")
+    core.show_message(kaomoji.doubt() .. " Really? If so, use `Done!`", "ErrorMsg")
     return
   end
 

--- a/lua/do/core.lua
+++ b/lua/do/core.lua
@@ -86,6 +86,7 @@ end
 --- configure displaying current to do item in winbar
 function C.setup_winbar()
   -- vim.o.winbar = view.stl
+  utils.redraw_winbar()
   vim.o.winbar = nil
   vim.api.nvim_create_autocmd({ "WinEnter", "BufEnter" }, {
     group = state.auGroupID,

--- a/lua/do/core.lua
+++ b/lua/do/core.lua
@@ -79,10 +79,11 @@ function C.setup_winbar()
     end
   })
 
+  -- winbar should not be displayed in windows the cursor is not in
   vim.api.nvim_create_autocmd({ "WinLeave", "BufLeave" }, {
     group = augroup,
     callback = function()
-       utils.redraw_winbar()
+       vim.wo.winbar = ""
     end
   })
 end

--- a/lua/do/core.lua
+++ b/lua/do/core.lua
@@ -43,10 +43,10 @@ function C.done()
   utils.redraw_winbar()
 end
 
+--- Edit the tasks in a floating window
 function C.edit()
   edit.toggle_edit(state.tasks:get(), function(new_todos)
     state.tasks:set(new_todos)
-    utils.redraw_winbar()
   end)
 end
 

--- a/lua/do/core.lua
+++ b/lua/do/core.lua
@@ -88,7 +88,10 @@ function C.setup_winbar()
   })
 end
 
+--- toggle the visibility of the winbar
 function C.toggle()
+   -- disable winbar completely when not visible
+   vim.wo.winbar = vim.wo.winbar == "" and view.stl or ""
   state.view_enabled = not state.view_enabled
 end
 

--- a/lua/do/core.lua
+++ b/lua/do/core.lua
@@ -27,6 +27,7 @@ function C.add(str, to_front)
   utils.redraw_winbar()
 end
 
+--- Finish the first task
 function C.done()
   if state.tasks:count() == 0 then
     C.show_message(kaomoji.confused() .. " There was nothing left to do…", "InfoMsg")

--- a/lua/do/core.lua
+++ b/lua/do/core.lua
@@ -62,13 +62,19 @@ function C.setup(opts)
   return C
 end
 
+--- configure displaying current to do item in winbar
 function C.setup_winbar()
-  vim.o.winbar = view.stl
+  -- vim.o.winbar = view.stl
+  vim.o.winbar = nil
   vim.api.nvim_create_autocmd({ "WinEnter", "BufEnter" }, {
     group = augroup,
     callback = function()
       if vim.fn.win_gettype() == "" and vim.bo.buftype ~= "prompt" then
-        vim.wo.winbar = view.stl
+         if C.has_items() then
+            vim.wo.winbar = view.render(state)
+         else
+            vim.wo.winbar = ""
+         end
       end
     end
   })
@@ -76,9 +82,14 @@ function C.setup_winbar()
   vim.api.nvim_create_autocmd({ "WinLeave", "BufLeave" }, {
     group = augroup,
     callback = function()
-      if vim.fn.win_gettype() == "" and vim.bo.buftype ~= "prompt" then
-        vim.wo.winbar = view.stl_nc
-      end
+       if vim.fn.win_gettype() == "" and vim.bo.buftype ~= "prompt" then
+          if C.has_items() then
+             vim.wo.winbar = view.render(state)
+             -- vim.wo.winbar = view.stl
+          else
+             vim.wo.winbar = ""
+          end
+       end
     end
   })
 end

--- a/lua/do/core.lua
+++ b/lua/do/core.lua
@@ -13,7 +13,6 @@ local augroup = vim.api.nvim_create_augroup("do_nvim", { clear = true })
 ---@param str string Text to display
 ---@param hl? string Highlight group
 function C.show_message(str, hl)
-  -- vim.wo.winbar = "%#" .. (hl or "TablineSel") .. "#" .. str
   state.message = "%#" .. (hl or "TablineSel") .. "#" .. str
 
   vim.defer_fn(function()
@@ -25,7 +24,7 @@ end
 ---@param to_front boolean
 function C.add(str, to_front)
   state.tasks:add(str, to_front)
-  utils.render_winbar()
+  utils.redraw_winbar()
 end
 
 function C.done()
@@ -41,20 +40,20 @@ function C.done()
   else
     C.show_message(kaomoji.joy() .. " Great! Only " .. state.tasks:count() .. " to go.", "MoreMsg")
   end
-  utils.render_winbar()
+  utils.redraw_winbar()
 end
 
 function C.edit()
   edit.toggle_edit(state.tasks:get(), function(new_todos)
     state.tasks:set(new_todos)
-    utils.render_winbar()
+    utils.redraw_winbar()
   end)
 end
 
 --- save the tasks
 function C.save()
   state.tasks:sync(true)
-  utils.render_winbar()
+  utils.redraw_winbar()
 end
 
 ---@param opts DoOptions
@@ -76,14 +75,14 @@ function C.setup_winbar()
   vim.api.nvim_create_autocmd({ "WinEnter", "BufEnter" }, {
     group = augroup,
     callback = function()
-       utils.render_winbar()
+       utils.redraw_winbar()
     end
   })
 
   vim.api.nvim_create_autocmd({ "WinLeave", "BufLeave" }, {
     group = augroup,
     callback = function()
-       utils.render_winbar()
+       utils.redraw_winbar()
     end
   })
 end

--- a/lua/do/core.lua
+++ b/lua/do/core.lua
@@ -7,7 +7,6 @@ local state = require('do.state').state
 local default_opts = require('do.state').default_opts
 local utils = require('do.utils')
 
-local augroup = vim.api.nvim_create_augroup("do_nvim", { clear = true })
 
 ---Show a message for the duration of `options.message_timeout`
 ---@param str string Text to display
@@ -61,6 +60,7 @@ end
 function C.setup(opts)
   state.options = vim.tbl_deep_extend("force", default_opts, opts or {})
   state.tasks = store.init(state.options.store)
+  state.auGroupID = vim.api.nvim_create_augroup("do_nvim", { clear = true })
 
   if state.options.use_winbar then
     C.setup_winbar()
@@ -74,7 +74,7 @@ function C.setup_winbar()
   -- vim.o.winbar = view.stl
   vim.o.winbar = nil
   vim.api.nvim_create_autocmd({ "WinEnter", "BufEnter" }, {
-    group = augroup,
+    group = state.auGroupID,
     callback = function()
        utils.redraw_winbar()
     end
@@ -82,7 +82,7 @@ function C.setup_winbar()
 
   -- winbar should not be displayed in windows the cursor is not in
   vim.api.nvim_create_autocmd({ "WinLeave", "BufLeave" }, {
-    group = augroup,
+    group = state.auGroupID,
     callback = function()
        vim.wo.winbar = ""
     end

--- a/lua/do/edit.lua
+++ b/lua/do/edit.lua
@@ -11,7 +11,7 @@ local function open_float()
   local win = vim.api.nvim_open_win(bufnr, true, {
     relative = "editor",
     border = "rounded",
-    noautocmd = true,
+    noautocmd = false,
     col = vim.opt.columns:get()/2 - width/2,
     row = vim.opt.lines:get()/2 - height/2,
     width = width,
@@ -73,11 +73,9 @@ function M.toggle_edit(tasks, cb)
     M.close(cb)
   end, { buffer = global_buf })
 
-  local group = vim.api.nvim_create_augroup("do_nvim", { clear = true })
-
   -- event after tasks from pop up has been written to
   vim.api.nvim_create_autocmd("BufWriteCmd", {
-    group = group,
+    group = state.state.auGroupID,
     buffer = global_buf,
     callback = function()
        local new_todos = get_buf_tasks()
@@ -86,22 +84,10 @@ function M.toggle_edit(tasks, cb)
   })
 
   vim.api.nvim_create_autocmd("BufModifiedSet", {
-    group = group,
+    group = state.state.auGroupID,
     buffer = global_buf,
     callback = function()
       vim.api.nvim_buf_set_option(global_buf, "modified", false)
-    end
-  })
-
-  -- Leaving a popup window does not trigger BufEnter / BufLeave event. So winbar is not being refreshed. So we need to manually refresh
-  vim.api.nvim_create_autocmd({"BufLeave", "BufWinLeave"}, {
-    group = group,
-    buffer = global_buf,
-    callback = function()
-       -- wait till we leave the pop up window before redrawing winbar on the under lying window
-       vim.defer_fn(function()
-          utils.redraw_winbar()
-       end, 100)
     end
   })
 end

--- a/lua/do/edit.lua
+++ b/lua/do/edit.lua
@@ -75,6 +75,7 @@ function M.toggle_edit(tasks, cb)
 
   local group = vim.api.nvim_create_augroup("do_nvim", { clear = true })
 
+  -- event after tasks from pop up has been written to
   vim.api.nvim_create_autocmd("BufWriteCmd", {
     group = group,
     buffer = global_buf,
@@ -89,6 +90,18 @@ function M.toggle_edit(tasks, cb)
     buffer = global_buf,
     callback = function()
       vim.api.nvim_buf_set_option(global_buf, "modified", false)
+    end
+  })
+
+  -- Leaving a popup window does not trigger BufEnter / BufLeave event. So winbar is not being refreshed. So we need to manually refresh
+  vim.api.nvim_create_autocmd({"BufLeave", "BufWinLeave"}, {
+    group = group,
+    buffer = global_buf,
+    callback = function()
+       -- wait till we leave the pop up window before redrawing winbar on the under lying window
+       vim.defer_fn(function()
+          utils.redraw_winbar()
+       end, 100)
     end
   })
 end

--- a/lua/do/kaomojis.lua
+++ b/lua/do/kaomojis.lua
@@ -1,4 +1,4 @@
-local utils = require('do.utils')
+-- local utils = require('do.utils')
 local joy = vim.split([[
 (* ^ ω ^)
 (´ ∀ ` *)
@@ -145,9 +145,23 @@ local doing = vim.split([[
 (｡•̀ᴗ-)✧
 ]], "\n")
 
+-- NOTE: had to move this here to avoid circular requirements
+local memo_store = {}
+setmetatable(memo_store, {__mode = "v"})  -- make values weak
+local function memo_random(table, seed)
+  local key = seed or math.random(#table)
+
+  if memo_store[key] then
+    return memo_store[key]
+  else
+    local newcolor = table[math.random(#table)]
+    memo_store[key] = newcolor
+    return newcolor
+  end
+end
 return {
-  doubt = function(seed) return utils.memo_random(doubt, seed) end,
-  confused = function(seed) return utils.memo_random(confused, seed) end,
-  joy = function(seed) return utils.memo_random(joy, seed) end,
-  doing = function(seed) return utils.memo_random(doing, seed) end,
+  doubt = function(seed) return memo_random(doubt, seed) end,
+  confused = function(seed) return memo_random(confused, seed) end,
+  joy = function(seed) return memo_random(joy, seed) end,
+  doing = function(seed) return memo_random(doing, seed) end,
 }

--- a/lua/do/state.lua
+++ b/lua/do/state.lua
@@ -23,12 +23,14 @@ M.default_opts = {
 ---@field message? string
 ---@field tasks nil | TaskStore
 ---@field options DoOptions
+---@field auGroupID number | nil
 M.state = {
   view_enabled = true,
   tasks = nil,
   message = nil,
   kaomoji = nil,
-  options = M.default_opts
+  options = M.default_opts,
+  auGroupID = nil
 }
 
 return M

--- a/lua/do/utils.lua
+++ b/lua/do/utils.lua
@@ -19,20 +19,6 @@ function M.memoize(f)
   return table
 end
 
--- local memo_store = {}
--- setmetatable(memo_store, {__mode = "v"})  -- make values weak
--- function M.memo_random(table, seed)
--- local key = seed or math.random(#table)
-
--- if memo_store[key] then
--- return memo_store[key]
--- else
--- local newcolor = table[math.random(#table)]
--- memo_store[key] = newcolor
--- return newcolor
--- end
--- end
-
 --- Render winbar depending on if there are tasks. Return true if winbar was rendered. False if winbar was disabled
 ---@return boolean
 function M.redraw_winbar()

--- a/lua/do/utils.lua
+++ b/lua/do/utils.lua
@@ -1,4 +1,3 @@
-local state = require("do.state").state
 local M = {}
 local state = require('do.state').state
 local view = require('do.view')

--- a/lua/do/utils.lua
+++ b/lua/do/utils.lua
@@ -19,16 +19,15 @@ function M.memoize(f)
   return table
 end
 
---- Render winbar depending on if there are tasks. Return true if winbar was rendered. False if winbar was disabled
----@return boolean
+--- Redraw winbar depending on if there are tasks. Redraw if there are pending tasks, other wise set to ""
 function M.redraw_winbar()
    if vim.fn.win_gettype() == "" and vim.bo.buftype ~= "prompt" then
       if state.tasks:count() > 0 then
          vim.wo.winbar = view.stl
+         -- vim.wo.winbar = "HELLO"
       else
          vim.wo.winbar = ""
       end
    end
-   return false
 end
 return M

--- a/lua/do/utils.lua
+++ b/lua/do/utils.lua
@@ -35,10 +35,10 @@ end
 
 --- Render winbar depending on if there are tasks. Return true if winbar was rendered. False if winbar was disabled
 ---@return boolean
-function M.render_winbar()
+function M.redraw_winbar()
    if vim.fn.win_gettype() == "" and vim.bo.buftype ~= "prompt" then
       if state.tasks:count() > 0 then
-         vim.wo.winbar = view.render(state)
+         vim.wo.winbar = view.stl
       else
          vim.wo.winbar = ""
       end

--- a/lua/do/utils.lua
+++ b/lua/do/utils.lua
@@ -1,4 +1,6 @@
 local M = {}
+local state = require('do.state').state
+local view = require('do.view')
 
 function M.is_white_space(str)
   return str:gsub("%s", "") == ""
@@ -31,4 +33,16 @@ end
 -- end
 -- end
 
+--- Render winbar depending on if there are tasks. Return true if winbar was rendered. False if winbar was disabled
+---@return boolean
+function M.render_winbar()
+   if vim.fn.win_gettype() == "" and vim.bo.buftype ~= "prompt" then
+      if state.tasks:count() > 0 then
+         vim.wo.winbar = view.render(state)
+      else
+         vim.wo.winbar = ""
+      end
+   end
+   return false
+end
 return M

--- a/lua/do/utils.lua
+++ b/lua/do/utils.lua
@@ -17,18 +17,18 @@ function M.memoize(f)
   return table
 end
 
-local memo_store = {}
-setmetatable(memo_store, {__mode = "v"})  -- make values weak
-function M.memo_random(table, seed)
-  local key = seed or math.random(#table)
+-- local memo_store = {}
+-- setmetatable(memo_store, {__mode = "v"})  -- make values weak
+-- function M.memo_random(table, seed)
+-- local key = seed or math.random(#table)
 
-  if memo_store[key] then 
-    return memo_store[key]
-  else
-    local newcolor = table[math.random(#table)]
-    memo_store[key] = newcolor
-    return newcolor
-  end
-end
+-- if memo_store[key] then
+-- return memo_store[key]
+-- else
+-- local newcolor = table[math.random(#table)]
+-- memo_store[key] = newcolor
+-- return newcolor
+-- end
+-- end
 
 return M

--- a/lua/do/utils.lua
+++ b/lua/do/utils.lua
@@ -22,10 +22,11 @@ end
 --- Redraw winbar depending on if there are tasks. Redraw if there are pending tasks, other wise set to ""
 function M.redraw_winbar()
    if vim.fn.win_gettype() == "" and vim.bo.buftype ~= "prompt" then
+      -- if there are tasks, make winbar visible
       if state.tasks:count() > 0 then
          vim.wo.winbar = view.stl
-         -- vim.wo.winbar = "HELLO"
       else
+         -- other wise hide it
          vim.wo.winbar = ""
       end
    end

--- a/lua/do/view.lua
+++ b/lua/do/view.lua
@@ -1,5 +1,5 @@
-local kaomojis = require("do.kaomojis")
 local View = {}
+local kaomojis = require("do.kaomojis")
 
 --- Weather the winbar should visible, when view_enabled is true, and there are items in the list
 ---@param state DoState
@@ -13,8 +13,6 @@ end
 ---@return string
 function View.render(state)
   if not View.is_visible(state) then
-     -- if view is not visible, disable winbar
-     vim.api.nvim_win_set_option(0, "winbar", nil)
     return ""
   end
 

--- a/lua/do/view.lua
+++ b/lua/do/view.lua
@@ -1,15 +1,20 @@
 local kaomojis = require("do.kaomojis")
 local View = {}
 
+--- Weather the winbar should visible, when view_enabled is true, and there are items in the list
+---@param state DoState
+---@return boolean
 function View.is_visible(state)
   return state.view_enabled and state.tasks:has_items()
 end
 
----comment
+---Create a string for the winbar
 ---@param state DoState
 ---@return string
 function View.render(state)
   if not View.is_visible(state) then
+     -- if view is not visible, disable winbar
+     vim.api.nvim_win_set_option(0, "winbar", nil)
     return ""
   end
 

--- a/tests/do_spec.lua
+++ b/tests/do_spec.lua
@@ -82,6 +82,11 @@ describe(":Do!", function()
 
 		local current_tasks = get_task_list()
 		assert.are.equals(current_tasks[1], task_name)
+
+      -- clean up
+		for _, _ in ipairs(tasks) do
+			vim.cmd(":Done!")
+		end
 	end)
 
 	it("should add a task to the end of the list", function()
@@ -109,7 +114,6 @@ end)
 
 describe("winbar shows the correct values", function()
 	it("should show the current task name with only 1 task in the list", function()
-		require("do").setup({})
 		add_task("test", true)
 		local winbar_value = vim.api.nvim_get_option_value("winbar", { scope = "local" })
 		assert.are.equal(winbar_value, "%!v:lua.DoStatusline('active')")

--- a/tests/do_spec.lua
+++ b/tests/do_spec.lua
@@ -31,5 +31,17 @@ describe("Setup", function()
 	end)
 end)
 
-describe(":Do", function()
+describe(":Do!", function()
+	it("should add a task to an empty task list", function()
+		local task_name = "test task"
+		vim.cmd(":Do! " .. task_name)
+
+		vim.cmd(":DoEdit")
+
+		-- get all the tasks in the buffer
+		local tasks = vim.api.nvim_buf_get_lines(0, -2, -1, false)
+      -- check if our task is among the tasks stored
+		assert.are.equals(vim.tbl_contains(tasks, task_name), true)
+	end)
+
 end)

--- a/tests/do_spec.lua
+++ b/tests/do_spec.lua
@@ -1,0 +1,33 @@
+local do_nvim = require("do")
+describe("Setup", function()
+	it("should set up default values if no user config is provided", function()
+		local state = require("do.state").state
+		local default_opts = require("do.state").default_opts
+		do_nvim.setup({})
+		assert.are.same(state.options, default_opts)
+	end)
+
+	it("should use custom config when setup is called", function()
+		local state = require("do.state").state
+		local default_opts = require("do.state").default_opts
+		local opts = {
+			-- default options
+			message_timeout = 2000, -- how long notifications are shown
+			kaomoji_mode = 0, -- 0 kaomoji everywhere, 1 skip kaomoji in doing
+			doing_prefix = "xxx: ",
+			use_winbar = true,
+			store = {
+				auto_create_file = false, -- automatically create a .do_tasks when calling :Do
+				file_name = ".do_taskssss",
+			},
+		}
+		do_nvim.setup(opts)
+
+		assert.are.same(state.options.message_timeout, opts.message_timeout)
+		assert.are.same(state.options.kaomoji_mode, opts.kaomoji_mode)
+		assert.are.same(state.options.doing_prefix, opts.doing_prefix)
+		assert.are.same(state.options.use_winbar, opts.use_winbar)
+		assert.are.same(state.options.store.auto_create_file, opts.store.auto_create_file)
+		assert.are.same(state.options.store.file_name, opts.store.file_name)
+	end)
+end)

--- a/tests/do_spec.lua
+++ b/tests/do_spec.lua
@@ -6,9 +6,19 @@ local function get_task_list()
 	vim.cmd(":DoEdit")
 	-- get all the tasks in the buffer
 	local tasks = vim.api.nvim_buf_get_lines(0, 0, 100, false)
-	print("get_task_list tasks:", vim.inspect(tasks)) -- __AUTO_GENERATED_PRINT_VAR__
 	vim.cmd(":q!")
 	return tasks
+end
+
+--- add a task to the list of tasks
+---@param task_name string name of task
+---@param front boolean if task should be added to front of list
+local function add_task(task_name, front)
+	if front then
+		vim.cmd(":Do! " .. task_name)
+	else
+		vim.cmd(":Do " .. task_name)
+	end
 end
 
 describe("Setup", function()
@@ -87,13 +97,21 @@ describe(":Do!", function()
 
 		-- add a series of tasks
 		for _, task in ipairs(tasks) do
-			vim.cmd(":Do! " .. task)
+			add_task(task, true)
 		end
 
-		vim.cmd(":Do " .. task_name)
-
+		add_task(task_name, false)
 		local current_tasks = get_task_list()
 		-- check if the last task is the one we expect
 		assert.are.equals(current_tasks[#current_tasks], task_name)
+	end)
+end)
+
+describe("winbar shows the correct values", function()
+	it("should show the current task name with only 1 task in the list", function()
+		require("do").setup({})
+		add_task("test", true)
+		local winbar_value = vim.api.nvim_get_option_value("winbar", { scope = "local" })
+		assert.are.equal(winbar_value, "%!v:lua.DoStatusline('active')")
 	end)
 end)

--- a/tests/do_spec.lua
+++ b/tests/do_spec.lua
@@ -1,5 +1,16 @@
 local do_nvim = require("do")
 
+--- Get the list of current tasks from `:DoEdit`
+---@return string[]
+local function get_task_list()
+	vim.cmd(":DoEdit")
+	-- get all the tasks in the buffer
+	local tasks = vim.api.nvim_buf_get_lines(0, 0, 100, false)
+	print("get_task_list tasks:", vim.inspect(tasks)) -- __AUTO_GENERATED_PRINT_VAR__
+	vim.cmd(":q!")
+	return tasks
+end
+
 describe("Setup", function()
 	it("should set up default values if no user config is provided", function()
 		local state = require("do.state").state
@@ -36,12 +47,53 @@ describe(":Do!", function()
 		local task_name = "test task"
 		vim.cmd(":Do! " .. task_name)
 
-		vim.cmd(":DoEdit")
-
-		-- get all the tasks in the buffer
-		local tasks = vim.api.nvim_buf_get_lines(0, -2, -1, false)
-      -- check if our task is among the tasks stored
+		local tasks = get_task_list()
+		-- check if our task is among the tasks stored
 		assert.are.equals(vim.tbl_contains(tasks, task_name), true)
 	end)
 
+	it("should add a task to the beginning of the list", function()
+		local tasks = {
+			"test1",
+			"test2",
+			"test3",
+			"test4",
+		}
+		local task_name = "new task"
+
+		vim.cmd(":Done!")
+
+		-- add a series of tasks
+		for _, task in ipairs(tasks) do
+			vim.cmd(":Do! " .. task)
+		end
+
+		vim.cmd(":Do! " .. task_name)
+
+		local current_tasks = get_task_list()
+		assert.are.equals(current_tasks[1], task_name)
+	end)
+
+	it("should add a task to the end of the list", function()
+		local tasks = {
+			"test1",
+			"test2",
+			"test3",
+			"test4",
+		}
+		local task_name = "new task"
+
+		vim.cmd(":Done!")
+
+		-- add a series of tasks
+		for _, task in ipairs(tasks) do
+			vim.cmd(":Do! " .. task)
+		end
+
+		vim.cmd(":Do " .. task_name)
+
+		local current_tasks = get_task_list()
+		-- check if the last task is the one we expect
+		assert.are.equals(current_tasks[#current_tasks], task_name)
+	end)
 end)

--- a/tests/do_spec.lua
+++ b/tests/do_spec.lua
@@ -1,4 +1,5 @@
 local do_nvim = require("do")
+
 describe("Setup", function()
 	it("should set up default values if no user config is provided", function()
 		local state = require("do.state").state
@@ -9,9 +10,7 @@ describe("Setup", function()
 
 	it("should use custom config when setup is called", function()
 		local state = require("do.state").state
-		local default_opts = require("do.state").default_opts
 		local opts = {
-			-- default options
 			message_timeout = 2000, -- how long notifications are shown
 			kaomoji_mode = 0, -- 0 kaomoji everywhere, 1 skip kaomoji in doing
 			doing_prefix = "xxx: ",
@@ -30,4 +29,7 @@ describe("Setup", function()
 		assert.are.same(state.options.store.auto_create_file, opts.store.auto_create_file)
 		assert.are.same(state.options.store.file_name, opts.store.file_name)
 	end)
+end)
+
+describe(":Do", function()
 end)

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -6,3 +6,4 @@ vim.o.swapfile = false
 require("do").setup({
   use_winbar = true
 })
+


### PR DESCRIPTION
- chore: add docs
- feat(core): disable winbar if we dont have items to display
- refactor: random number generator moved into `kaomojis` module
- feat: render winbar when the todo list is modified
- refactor: rename `render_winbar()` -> `redraw_winbar`
- fix: winbar should not display in windows without cursor
- feat: disable winbar completely when toggled off
- chore(utils): remove comments
- fix: handle when exiting a pop up window
- test: add setup() tests
- chore: remove comments
- test: `Do!` to an empty task list
- test: `:Do[!]` adds to the beginning and end of the list
- test(winbar): shows the correct values with 1 task
- chore: add comments and clean up code
- fix: `:DoEdit` performs as expected
- fix: redraw winbar on start up
